### PR TITLE
Create first version of the API

### DIFF
--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -16,5 +16,6 @@ export default defineEventHandler<Response>(() => {
 		emoji: message.emoji,
 		message: message.message,
 		shouldIDeploy: shouldIDeploy(day),
+		timestamp: date.toISOString(),
 	};
 });

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -1,0 +1,20 @@
+import { Message } from "../utils/messages";
+
+type Response = {
+	emoji: string;
+	message: string;
+	shouldIDeploy: boolean;
+}
+
+export default defineEventHandler<Response>(() => {
+	const timezoneOffset: number = 180 * 60 * 1000;
+	const date: Date = new Date(Date.now() - timezoneOffset);
+	const day: number = date.getDay();
+	const message: Message = getRandomMessage(messages[getWeekday(day)]);
+
+	return {
+		emoji: message.emoji,
+		message: message.message,
+		shouldIDeploy: shouldIDeploy(day),
+	};
+});

--- a/server/api/utils/messages.ts
+++ b/server/api/utils/messages.ts
@@ -1,0 +1,76 @@
+interface Message {
+	emoji: string;
+	message: string;
+}
+
+interface Messages {
+	[key: string]: Message[];
+}
+
+const messages: Messages = {
+	monday: [
+		{
+			emoji: "⌚️",
+			message:
+				"Você ainda tem bastante tempo pra resolver suas cagadas essa semana",
+		},
+		{ emoji: "👾", message: "Só se você confiar nos seus testes e debugs" },
+		{
+			emoji: "📈",
+			message: "Terça-feira é um bom dia pra corrigir os bugs de segunda",
+		},
+		{
+			emoji: "⌚️",
+			message: "Se der errado, você tem a semana toda pra corrigir",
+		},
+	],
+
+	tuesday: [
+		{ emoji: "💤", message: "Só se você não quiser passar a noite acordado" },
+		{ emoji: "☕️", message: "Tome um café e bora" },
+		{ emoji: "📅", message: "Os bugs aumentam, o prazo não" },
+		{
+			emoji: "💣️",
+			message: "Se estiver inseguro é só jogar a bomba pro colega de time",
+		},
+	],
+
+	wednesday: [
+		{ emoji: "⚽️", message: "O futebol de quarta à noite te espera" },
+		{ emoji: "🗓️", message: "O dia da entrega está chegando" },
+		{ emoji: "🖥️", message: "Não dá pra usar se estiver só na sua máquina" },
+		{ emoji: "💸", message: "Você não gasta com hospedagem a toa" },
+	],
+
+	thursday: [
+		{ emoji: "🕔️", message: "Antes tarde do que sexta" },
+		{ emoji: "📅", message: "Sua última oportunidade pra cumprir o prazo" },
+		{ emoji: "🎶", message: "“It's the final countdown”" },
+		{ emoji: "🧾", message: "Testou tudo ou só quer bater ponto?" },
+	],
+
+	friday: [
+		{ emoji: "❌", message: "Não." },
+		{ emoji: "🍺", message: "E a breja?" },
+		{ emoji: "🗓️", message: "Codar no fim de semana?" },
+		{ emoji: "🚀🛑", message: "Esse foguete tem ré" },
+		{ emoji: "🚧", message: "Deixa isso aí pra segunda-feira" },
+		{ emoji: "🍺", message: "Codar bêbado não vai dar certo" },
+	],
+
+	easter: [
+		{ emoji: "🍫", message: "Vai trocar o chocolate por isso?" },
+		{
+			emoji: "💸",
+			message: "Não gastaram 100 reais no seu presente da Cacau Show à toa",
+		},
+		{ emoji: "✝️", message: "Vai ter que ressuscitar igual Jesus" },
+		{
+			emoji: "💼",
+			message: "Páscoa significa passagem, igual sua passagem no RH",
+		},
+		{ emoji: "🍲", message: "E o almoço de família?" },
+	],
+};
+
+export default messages;

--- a/server/api/utils/messages.ts
+++ b/server/api/utils/messages.ts
@@ -1,9 +1,9 @@
-interface Message {
+type Message = {
 	emoji: string;
 	message: string;
 }
 
-interface Messages {
+type Messages = {
 	[key: string]: Message[];
 }
 

--- a/server/utils/dayUtils.ts
+++ b/server/utils/dayUtils.ts
@@ -1,0 +1,11 @@
+const weekdays: string[] = [
+	"sunday",
+	"monday",
+	"tuesday",
+	"wednesday",
+	"thursday",
+	"friday",
+	"saturday",
+];
+
+export const getWeekday = (day: number) => weekdays[day];

--- a/server/utils/getRandomMessage.ts
+++ b/server/utils/getRandomMessage.ts
@@ -1,0 +1,5 @@
+import { Message } from "./messages";
+
+const getRandomMessage = (messages: Message[]) =>  messages[Math.floor(Math.random() * messages.length)];
+
+export default getRandomMessage;

--- a/server/utils/messages.ts
+++ b/server/utils/messages.ts
@@ -1,11 +1,11 @@
-type Message = {
+export type Message = {
 	emoji: string;
 	message: string;
-}
+};
 
 type Messages = {
 	[key: string]: Message[];
-}
+};
 
 const messages: Messages = {
 	monday: [
@@ -49,13 +49,33 @@ const messages: Messages = {
 		{ emoji: "🧾", message: "Testou tudo ou só quer bater ponto?" },
 	],
 
-	friday: [
+	weekend: [
 		{ emoji: "❌", message: "Não." },
 		{ emoji: "🍺", message: "E a breja?" },
 		{ emoji: "🗓️", message: "Codar no fim de semana?" },
 		{ emoji: "🚀🛑", message: "Esse foguete tem ré" },
 		{ emoji: "🚧", message: "Deixa isso aí pra segunda-feira" },
 		{ emoji: "🍺", message: "Codar bêbado não vai dar certo" },
+		{ emoji: "😵‍💫", message: "Você é louco?" },
+	],
+
+	friday: [
+		{ emoji: "📅", message: "Sextou!" },
+		{ emoji: "⌛️", message: "Tarde demais" },
+		{ emoji: "🚧", message: "Deixa isso aí pra segunda-feira" },
+		{ emoji: "⌛️", message: "Justo no último dia útil?" },
+	],
+
+	saturday: [
+		{ emoji: "🏖️", message: "Vai pra praia e esquece isso" },
+		{ emoji: "📅", message: "Sabadou!" },
+	],
+
+	sunday: [
+		{ emoji: "🗓️", message: "Deixa pra amanhã" },
+		{ emoji: "🥩", message: "Vai assar uma carne, vai" },
+		{ emoji: "📅", message: "Domingou!" },
+		{ emoji: "⏳️", message: "Só mais um dia" },
 	],
 
 	easter: [
@@ -72,5 +92,9 @@ const messages: Messages = {
 		{ emoji: "🍲", message: "E o almoço de família?" },
 	],
 };
+
+messages.friday = [...messages.friday, ...messages.weekend];
+messages.saturday = [...messages.saturday, ...messages.weekend];
+messages.sunday = [...messages.sunday, ...messages.weekend];
 
 export default messages;

--- a/server/utils/shouldIDeploy.ts
+++ b/server/utils/shouldIDeploy.ts
@@ -1,0 +1,1 @@
+export const shouldIDeploy = (day: number) => day > 0 && day < 5;


### PR DESCRIPTION
Created a basic version of the API, at the endpoint `/api/`.
Actually returns an emoji, a message, a boolean `shouldIDeploy` and the timestamp, based on the weekday (sunday, monday, tuesday...). 
The usage in the front-end is not implemented yet.

Closes #2 